### PR TITLE
Add solution filter for non Windows build

### DIFF
--- a/ScadaAdmin/OpenExtensions/OpenExtensions.slnf
+++ b/ScadaAdmin/OpenExtensions/OpenExtensions.slnf
@@ -1,0 +1,6 @@
+{
+  "solution": {
+    "path": "OpenExtensions.sln",
+    "projects": [] // All projects for Windows target
+  }
+}

--- a/ScadaAdmin/ScadaAdmin/ScadaAdmin.slnf
+++ b/ScadaAdmin/ScadaAdmin/ScadaAdmin.slnf
@@ -1,0 +1,6 @@
+{
+  "solution": {
+    "path": "ScadaAdmin.sln",
+    "projects": [] // All projects for Windows target
+  }
+}

--- a/ScadaComm/OpenDrivers/OpenDrivers.slnf
+++ b/ScadaComm/OpenDrivers/OpenDrivers.slnf
@@ -1,0 +1,37 @@
+{
+  "solution": {
+    "path": "OpenDrivers.sln",
+    "projects": [
+        "DrvSimulator",
+        "DrvSimulator.Logic\\DrvSimulator.Logic.csproj",
+        "DrvCnlBasic",
+        "DrvCnlBasic.Logic\\DrvCnlBasic.Logic.csproj",
+        "DrvDsScadaServer",
+        "DrvDsScadaServer.Logic\\DrvDsScadaServer.Logic.csproj",
+        "DrvDsOpcUaServer",
+        "DrvDsOpcUaServer.Logic\\DrvDsOpcUaServer.Logic.csproj",
+        "Solution Items",
+        "DrvDsOpcUaServer.Common\\DrvDsOpcUaServer.Common.csproj",
+        "DrvModbus.Common\\DrvModbus.Common.csproj",
+        "DrvModbus.Logic\\DrvModbus.Logic.csproj",
+        "DrvOpcUa",
+        "DrvOpcUa.Logic\\DrvOpcUa.Logic.csproj",
+        "DrvOpcUa.Common\\DrvOpcUa.Common.csproj",
+        "DrvSimulator.Shared\\DrvSimulator.Shared.shproj",
+        "DrvTester",
+        "DrvTester.Logic\\DrvTester.Logic.csproj",
+        "DrvTester.Shared\\DrvTester.Shared.shproj",
+        "DrvMqtt",
+        "DrvMqtt.Common\\DrvMqtt.Common.csproj",
+        "DrvCnlMqtt.Logic\\DrvCnlMqtt.Logic.csproj",
+        "DrvMqttClient.Logic\\DrvMqttClient.Logic.csproj",
+        "DrvMqttPublisher.Logic\\DrvMqttPublisher.Logic.csproj",
+        "DrvMqttPublisher.Shared\\DrvMqttPublisher.Shared.shproj",
+        "DrvDsMqtt.Logic\\DrvDsMqtt.Logic.csproj",
+        "DrvDsMqtt.Shared\\DrvDsMqtt.Shared.shproj",
+        "DrvMqttClient.Common\\DrvMqttClient.Common.csproj",
+        "DrvCnlBasic.Shared\\DrvCnlBasic.Shared.shproj",
+        "DrvDsScadaServer.Shared\\DrvDsScadaServer.Shared.shproj"
+    ]
+  }
+}

--- a/ScadaComm/OpenDrivers2/OpenDrivers2.slnf
+++ b/ScadaComm/OpenDrivers2/OpenDrivers2.slnf
@@ -1,0 +1,16 @@
+{
+  "solution": {
+    "path": "OpenDrivers2.sln",
+    "projects": [
+      "AddressBook\\AddressBook.csproj",
+      "AddressBookProjects",
+      "DrvHttpNotif",
+      "DrvHttpNotif.Shared\\DrvHttpNotif.Shared.shproj",
+      "DrvHttpNotif.Logic\\DrvHttpNotif.Logic.csproj",
+      "Solution Items",
+      "DrvEmail",
+      "DrvEmail.Shared\\DrvEmail.Shared.shproj",
+      "DrvEmail.Logic\\DrvEmail.Logic.csproj"
+    ]
+  }
+}

--- a/ScadaComm/ScadaComm/ScadaComm.slnf
+++ b/ScadaComm/ScadaComm/ScadaComm.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "ScadaComm.sln",
+    "projects": [
+      "ScadaCommCommon\\ScadaCommCommon.csproj",
+      "ScadaCommApp\\ScadaCommApp.csproj",
+      "ScadaCommEngine\\ScadaCommEngine.csproj",
+      "ScadaCommWkr\\ScadaCommWkr.csproj"
+    ]
+  }
+}

--- a/ScadaCommon/ScadaCommon.slnf
+++ b/ScadaCommon/ScadaCommon.slnf
@@ -1,0 +1,12 @@
+{
+  "solution": {
+    "path": "ScadaCommon.sln",
+    "projects": [
+      "ScadaCommon\\ScadaCommon.csproj",
+      "ScadaCommon.Log\\ScadaCommon.Log.csproj",
+      "Storages",
+      "FileStorage\\FileStorage.csproj",
+      "PostgreSqlStorage\\PostgreSqlStorage.csproj"
+    ]
+  }
+}

--- a/ScadaServer/OpenModules/OpenModules.slnf
+++ b/ScadaServer/OpenModules/OpenModules.slnf
@@ -1,0 +1,17 @@
+{
+  "solution": {
+    "path": "OpenModules.sln",
+    "projects": [
+      "ModArcBasic.Logic\\ModArcBasic.Logic.csproj",
+      "ModArcBasic",
+      "Solution Items",
+      "ModArcPostgreSql",
+      "ModArcPostgreSql.Logic\\ModArcPostgreSql.Logic.csproj",
+      "ModArcInfluxDb",
+      "ModArcInfluxDb.Logic\\ModArcInfluxDb.Logic.csproj",
+      "ModArcInfluxDb.Shared\\ModArcInfluxDb.Shared.shproj",
+      "ModArcBasic.Shared\\ModArcBasic.Shared.shproj",
+      "ModArcPostgreSql.Shared\\ModArcPostgreSql.Shared.shproj"
+    ]
+  }
+}

--- a/ScadaServer/ScadaServer/ScadaServer.slnf
+++ b/ScadaServer/ScadaServer/ScadaServer.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "ScadaServer.sln",
+    "projects": [
+      "ScadaServerCommon\\ScadaServerCommon.csproj",
+      "ScadaServerEngine\\ScadaServerEngine.csproj",
+      "ScadaServerApp\\ScadaServerApp.csproj",
+      "ScadaServerWkr\\ScadaServerWkr.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
For example, we can build without compiling error on Linux with "dotnet build ScadaCommon.slnf -c Release" command