### PR TITLE
ScadaAdmin: Exclude common libs from being embedded

### DIFF
--- a/ScadaAdmin/ScadaAdmin/ScadaAdmin/ScadaAdmin.csproj
+++ b/ScadaAdmin/ScadaAdmin/ScadaAdmin/ScadaAdmin.csproj
@@ -54,27 +54,35 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ScadaAdminCommon\ScadaAdminCommon.csproj" />
+    <ProjectReference Include="..\ScadaAdminCommon\ScadaAdminCommon.csproj">
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="AgentClient">
       <HintPath>..\..\..\ScadaAgent\ScadaAgent\AgentClient\bin\Release\netstandard2.0\AgentClient.dll</HintPath>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Reference>
     <Reference Include="ScadaCommCommon">
       <HintPath>..\..\..\ScadaComm\ScadaComm\ScadaCommCommon\bin\Release\netstandard2.0\ScadaCommCommon.dll</HintPath>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Reference>
     <Reference Include="ScadaCommon">
       <HintPath>..\..\..\ScadaCommon\ScadaCommon\bin\Release\netstandard2.0\ScadaCommon.dll</HintPath>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Reference>
     <Reference Include="ScadaCommon.Forms">
       <HintPath>..\..\..\ScadaCommon\ScadaCommon.Forms\bin\Release\net6.0-windows\ScadaCommon.Forms.dll</HintPath>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Reference>
     <Reference Include="ScadaCommon.Log">
       <HintPath>..\..\..\ScadaCommon\ScadaCommon.Log\bin\Release\netstandard2.0\ScadaCommon.Log.dll</HintPath>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Reference>
     <Reference Include="ScadaServerCommon">
       <HintPath>..\..\..\ScadaServer\ScadaServer\ScadaServerCommon\bin\Release\netstandard2.0\ScadaServerCommon.dll</HintPath>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
Useful for Administrator as a portable application or Wine distribution in single-file executable but not bundle common libs in the file.

Reference:
https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/overview?tabs=cli