### PR TITLE
FrameworkDescription's value is .NET instead of .NET Core

### DIFF
--- a/ScadaCommon/ScadaCommon/ScadaUtils.cs
+++ b/ScadaCommon/ScadaCommon/ScadaUtils.cs
@@ -78,7 +78,7 @@ namespace Scada
         /// <summary>
         /// Determines that the application is running on .NET Core.
         /// </summary>
-        public static readonly bool IsRunningOnCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+        public static readonly bool IsRunningOnCore = RuntimeInformation.FrameworkDescription.StartsWith(".NET");
 
         #region Tables for calculating CRC-16.
         /* Table of CRC values for high–order byte */


### PR DESCRIPTION
Starting in .NET 5, RuntimeInformation.FrameworkDescription returns ".NET" as part of the description string https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/frameworkdescription-returns-net-not-net-core