### PR TITLE
ModArcPostgreSql: PartitionSize has been updated to support OneDay

### DIFF
--- a/ScadaServer/OpenModules/ModArcPostgreSql.Logic/DbUtils.cs
+++ b/ScadaServer/OpenModules/ModArcPostgreSql.Logic/DbUtils.cs
@@ -72,15 +72,20 @@ namespace Scada.Server.Modules.ModArcPostgreSql.Logic
             DateTime startDate;
             DateTime endDate;
 
-            if (partitionSize == PartitionSize.OneMonth)
+            switch (partitionSize)
             {
-                startDate = new DateTime(today.Year, today.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-                endDate = startDate.AddMonths(1);
-            }
-            else // PartitionSize.OneYear
-            {
-                startDate = new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-                endDate = startDate.AddYears(1);
+                case PartitionSize.OneDay:
+                    startDate = new DateTime(today.Year, today.Month, today.Day, 0, 0, 0, DateTimeKind.Utc);
+                    endDate = startDate.AddDays(1);
+                    break;
+                case PartitionSize.OneMonth:
+                    startDate = new DateTime(today.Year, today.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+                    endDate = startDate.AddMonths(1);
+                    break;
+                default: // PartitionSize.OneYear
+                    startDate = new DateTime(today.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                    endDate = startDate.AddYears(1);
+                    break;
             }
 
             partitionName = tableName +

--- a/ScadaServer/OpenModules/ModArcPostgreSql.Shared/Config/PartitionSize.cs
+++ b/ScadaServer/OpenModules/ModArcPostgreSql.Shared/Config/PartitionSize.cs
@@ -10,6 +10,7 @@ namespace Scada.Server.Modules.ModArcPostgreSql.Config
     internal enum PartitionSize
     {
         OneMonth,
-        OneYear
+        OneYear,
+        OneDay
     }
 }

--- a/ScadaServer/OpenModules/ModArcPostgreSql.View/Controls/CtrlDatabaseOptions.Designer.cs
+++ b/ScadaServer/OpenModules/ModArcPostgreSql.View/Controls/CtrlDatabaseOptions.Designer.cs
@@ -102,7 +102,7 @@
             // 
             cbPartitionSize.DropDownStyle = ComboBoxStyle.DropDownList;
             cbPartitionSize.FormattingEnabled = true;
-            cbPartitionSize.Items.AddRange(new object[] { "One month", "One year" });
+            cbPartitionSize.Items.AddRange(new object[] { "One month", "One year", "One day" });
             cbPartitionSize.Location = new Point(196, 81);
             cbPartitionSize.Name = "cbPartitionSize";
             cbPartitionSize.Size = new Size(151, 23);


### PR DESCRIPTION
Reason for addition: To improve performance on devices with limited storage space and slow read/write speeds.

Scenario example:
- The device is a Raspberry Pi 4B with 8GB RAM and a 64GB TF card.
- It has approximately 13,000 channels.
- It uses the ModArcPostgreSql module for archive.
- Historical data is sampled at a frequency of 1 minute.
- A custom synchronization service uploads historical data to the cloud.
- The device only keeps the latest 7 days of data for resending in case of interruptions.

When the PartitionSize is set to OneMonth, even though the retention policy is set to 7 days, the data is actually deleted after around 30+7 days. In the current scenario, only 15 days of data are needed to fill up the entire 64GB storage card, resulting in data collection interruptions.

The addition of the OneDay option resolves similar scenario requirements.

BTW, to avoid causing breaking changes, I have placed "OneDay" at the end. Actually, I really wanted to put it as the first option :p