### PR TITLE
DrvMqttClient update

### DIFF
--- a/ScadaComm/OpenDrivers/DrvMqttClient.Logic/DevMqttClientLogic.cs
+++ b/ScadaComm/OpenDrivers/DrvMqttClient.Logic/DevMqttClientLogic.cs
@@ -166,6 +166,13 @@ namespace Scada.Comm.Drivers.DrvMqttClient.Logic
 
             // set script methods and variables that depend on current call
             jsEngine.SetValue("setValue", new Action<int, double>((i, x) => { subscriptionTag.JsValues[i] = x; }));
+            jsEngine.SetValue("getValue", new Func<int, double>(i =>
+            {
+                int tagIndex = subscriptionTag.TagIndex + i;
+                return updateTimestamps[tagIndex] == DateTime.MinValue
+                    ? double.NaN
+                    : DeviceData.Get(tagIndex);
+            }));
             jsEngine.SetValue("topic", message.Topic);
             jsEngine.SetValue("payload", message.Payload);
 

--- a/ScadaComm/OpenDrivers/DrvMqttClient.Logic/DrvMqttClient.Logic.csproj
+++ b/ScadaComm/OpenDrivers/DrvMqttClient.Logic/DrvMqttClient.Logic.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" Version="2.11.58" />
+    <PackageReference Include="Jint" Version="3.1.2" />
     <PackageReference Include="MQTTnet" Version="4.1.4.563" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrade Jint to v3, with better performance and more modern js syntax support; add a new getValue() function to script, which can be used to retrieve the previous channel value.