### PR TITLE
DrvModbus: option for scaling

### DIFF
--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Config/CmdConfig.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Config/CmdConfig.cs
@@ -25,6 +25,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
             ElemType = DefaultElemType;
             ElemCnt = 1;
             ByteOrder = "";
+            Scaling = "";
             CmdNum = 0;
             CmdCode = "";
         }
@@ -54,6 +55,11 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
         /// Gets or sets the byte order.
         /// </summary>
         public string ByteOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scaling double array.
+        /// </summary>
+        public string Scaling { get; set; }
 
         /// <summary>
         /// Gets or sets the command number.
@@ -103,6 +109,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
             ElemType = xmlElem.GetAttrAsEnum("elemType", DefaultElemType);
             ElemCnt = xmlElem.GetAttrAsInt("elemCnt", 1);
             ByteOrder = xmlElem.GetAttrAsString("byteOrder");
+            Scaling = xmlElem.GetAttrAsString("scaling");
             CmdNum = xmlElem.GetAttrAsInt("cmdNum");
             CmdCode = xmlElem.GetAttrAsString("cmdCode");
             Name = xmlElem.GetAttrAsString("name");
@@ -135,6 +142,13 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
 
                 if (ByteOrderEnabled && !string.IsNullOrEmpty(ByteOrder))
                     xmlElem.SetAttribute("byteOrder", ByteOrder);
+
+                if (ScalingEnabled && !string.IsNullOrWhiteSpace(Scaling))
+                {
+                    double[] scaling = ModbusUtils.ParseDoubleArray(Scaling);
+                    if (scaling.Length == 4 && scaling[0] != scaling[1] && scaling[2] != scaling[3])
+                        xmlElem.SetAttribute("scaling", Scaling);
+                }
             }
 
             xmlElem.SetAttribute("cmdNum", CmdNum);

--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Config/DataUnitConfig.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Config/DataUnitConfig.cs
@@ -85,6 +85,17 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether a scaling is applicable for the elements.
+        /// </summary>
+        public virtual bool ScalingEnabled
+        {
+            get
+            {
+                return DataBlock == DataBlock.InputRegisters || DataBlock == DataBlock.HoldingRegisters;
+            }
+        }
+
 
         /// <summary>
         /// Gets the maximum number of elements depending on the data block.

--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Config/ElemConfig.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Config/ElemConfig.cs
@@ -22,6 +22,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
             ByteOrder = "";
             ReadOnly = false;
             IsBitMask = false;
+            Scaling = "";
         }
 
 
@@ -54,6 +55,11 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
         /// Gets or sets a value indicating whether the element represents a bit mask.
         /// </summary>
         public bool IsBitMask { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scaling double array.
+        /// </summary>
+        public string Scaling { get; set; }
 
         /// <summary>
         /// Gets the quantity of addresses.

--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Config/ElemGroupConfig.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Config/ElemGroupConfig.cs
@@ -100,6 +100,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
                 elemConfig.ByteOrder = elemElem.GetAttrAsString("byteOrder");
                 elemConfig.ReadOnly = elemElem.GetAttrAsBool("readOnly", defaultReadOnly);
                 elemConfig.IsBitMask = elemElem.GetAttrAsBool("isBitMask", defaultBitMask);
+                elemConfig.Scaling = elemElem.GetAttrAsString("scaling", "");
                 elemConfig.TagCode = elemElem.GetAttrAsString("tagCode");
                 elemConfig.Name = elemElem.GetAttrAsString("name");
                 Elems.Add(elemConfig);
@@ -123,6 +124,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
             bool byteOrderEnabled = ByteOrderEnabled;
             bool readOnlyEnabled = ReadOnlyEnabled;
             bool bitMaskEnabled = BitMaskEnabled;
+            bool scalingEnabled = ScalingEnabled;
 
             foreach (ElemConfig elemConfig in Elems)
             {
@@ -139,6 +141,13 @@ namespace Scada.Comm.Drivers.DrvModbus.Config
 
                 if (bitMaskEnabled)
                     elemElem.SetAttribute("isBitMask", elemConfig.IsBitMask);
+
+                if (scalingEnabled && !string.IsNullOrWhiteSpace(elemConfig.Scaling))
+                {
+                    double[] scaling = ModbusUtils.ParseDoubleArray(elemConfig.Scaling);
+                    if (scaling.Length == 4 && scaling[0] != scaling[1] && scaling[2] != scaling[3])
+                        elemElem.SetAttribute("scaling", elemConfig.Scaling);
+                }
 
                 elemElem.SetAttribute("tagCode", elemConfig.TagCode);
                 elemElem.SetAttribute("name", elemConfig.Name);

--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Protocol/Elem.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Protocol/Elem.cs
@@ -17,6 +17,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Protocol
             Name = "";
             ElemType = ElemType.Undefined;
             ByteOrder = null;
+            Scaling = "";
             Aux = null;
         }
 
@@ -35,6 +36,11 @@ namespace Scada.Comm.Drivers.DrvModbus.Protocol
         /// Gets or sets the byte order.
         /// </summary>
         public int[] ByteOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scaling double array.
+        /// </summary>
+        public string Scaling { get; set; }
 
         /// <summary>
         /// Gets or sets the auxiliary object.

--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Protocol/ElemGroup.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Protocol/ElemGroup.cs
@@ -196,12 +196,15 @@ namespace Scada.Comm.Drivers.DrvModbus.Protocol
             }
 
             // calculate value
+            double elemValue;
             switch (elem.ElemType)
             {
                 case ElemType.UShort:
-                    return BitConverter.ToUInt16(buf, 0);
+                    elemValue = BitConverter.ToUInt16(buf, 0);
+                    break;
                 case ElemType.Short:
-                    return BitConverter.ToInt16(buf, 0);
+                    elemValue = BitConverter.ToInt16(buf, 0);
+                    break;
                 case ElemType.UInt:
                     return BitConverter.ToUInt32(buf, 0);
                 case ElemType.Int:
@@ -219,6 +222,17 @@ namespace Scada.Comm.Drivers.DrvModbus.Protocol
                 default:
                     return 0.0;
             }
+
+            // Check if scaling is needed
+            if (!string.IsNullOrWhiteSpace(elem.Scaling))
+            {
+                double[] scaling = ModbusUtils.ParseDoubleArray(elem.Scaling);
+                if (scaling.Length == 4 && scaling[0] != scaling[1] && scaling[2] != scaling[3])
+                    return ModbusUtils.GetScaledValue(elemValue, scaling[0], scaling[1], scaling[2], scaling[3]);
+            }
+
+            // Return the original value
+            return elemValue;
         }
     }
 }

--- a/ScadaComm/OpenDrivers/DrvModbus.Common/Protocol/ModbusUtils.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Common/Protocol/ModbusUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Rapid Software LLC. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Globalization;
 
 namespace Scada.Comm.Drivers.DrvModbus.Protocol
@@ -334,6 +335,49 @@ namespace Scada.Comm.Drivers.DrvModbus.Protocol
                 funcCode == FunctionCode.WriteSingleRegister ||
                 funcCode == FunctionCode.WriteMultipleCoils ||
                 funcCode == FunctionCode.WriteMultipleRegisters;
+        }
+
+        /// <summary>
+        /// The array separator used for parsing.
+        /// </summary>
+        private static readonly char[] ParseArraySeparator = { ';', ',', ' ' };
+
+        /// <summary>
+        /// Converts the string representation of an array of double to its array equivalent.
+        /// </summary>
+        public static double[] ParseDoubleArray(string s)
+        {
+            try
+            {
+                string[] elems = (s ?? "").Split(ParseArraySeparator, StringSplitOptions.RemoveEmptyEntries);
+                int len = elems.Length;
+                double[] arr = new double[len];
+
+                for (int i = 0; i < len; i++)
+                {
+                    arr[i] = double.Parse(elems[i]);
+                }
+
+                return arr;
+            }
+            catch (FormatException ex)
+            {
+                throw new FormatException("The specified string is not an array of double.", ex);
+            }
+        }
+
+        /// <summary>
+        /// Transforms a value from one range to another.
+        /// </summary>
+        public static double GetScaledValue(double value, double min1, double max1, double min2, double max2)
+        {
+            if (min1 == max1)
+                throw new ArgumentException("The original range must have different minimum and maximum values.");
+
+            if (min2 == max2)
+                throw new ArgumentException("The new range must have different minimum and maximum values.");
+
+            return (value - min1) / (max1 - min1) * (max2 - min2) + min2;
         }
     }
 }

--- a/ScadaComm/OpenDrivers/DrvModbus.Logic/DevModbusLogic.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.Logic/DevModbusLogic.cs
@@ -67,6 +67,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Logic
             modbusCmd.ElemCnt = 1;
             modbusCmd.ByteOrder = ModbusUtils.ParseByteOrder(elemConfig.ByteOrder) ??
                 options.GetDefaultByteOrder(ModbusUtils.GetDataLength(elemConfig.ElemType));
+            modbusCmd.Scaling = elemConfig.Scaling;
             modbusCmd.CmdNum = 0;
             modbusCmd.CmdCode = elemConfig.TagCode;
 
@@ -87,6 +88,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Logic
             modbusCmd.ElemCnt = cmdConfig.ElemCnt;
             modbusCmd.ByteOrder = ModbusUtils.ParseByteOrder(cmdConfig.ByteOrder) ??
                 options.GetDefaultByteOrder(ModbusUtils.GetDataLength(cmdConfig.ElemType) * cmdConfig.ElemCnt);
+            modbusCmd.Scaling = cmdConfig.Scaling;
             modbusCmd.CmdNum = cmdConfig.CmdNum;
             modbusCmd.CmdCode = cmdConfig.CmdCode;
 
@@ -153,6 +155,8 @@ namespace Scada.Comm.Drivers.DrvModbus.Logic
                 return TagFormat.FloatNumber;
             else if (elemConfig.IsBitMask)
                 return TagFormat.HexNumber;
+            else if (!string.IsNullOrWhiteSpace(elemConfig.Scaling))
+                return TagFormat.FloatNumber;
             else
                 return TagFormat.IntNumber;
         }
@@ -288,6 +292,7 @@ namespace Scada.Comm.Drivers.DrvModbus.Logic
                         elem.ElemType = elemConfig.ElemType;
                         elem.ByteOrder = ModbusUtils.ParseByteOrder(elemConfig.ByteOrder) ??
                             deviceTemplate.Options.GetDefaultByteOrder(ModbusUtils.GetDataLength(elemConfig.ElemType));
+                        elem.Scaling = elemConfig.Scaling;
                         elemGroup.Elems.Add(elem);
                     }
 

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlCmd.Designer.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlCmd.Designer.cs
@@ -30,6 +30,9 @@
         {
             this.gbCmd = new System.Windows.Forms.GroupBox();
             this.pnlCmdElem = new System.Windows.Forms.Panel();
+            this.lblCmdScalingExample = new System.Windows.Forms.Label();
+            this.txtCmdScaling = new System.Windows.Forms.TextBox();
+            this.lblCmdScaling = new System.Windows.Forms.Label();
             this.lblCmdByteOrderExample = new System.Windows.Forms.Label();
             this.txtCmdByteOrder = new System.Windows.Forms.TextBox();
             this.lblCmdByteOrder = new System.Windows.Forms.Label();
@@ -86,13 +89,16 @@
             this.gbCmd.Location = new System.Drawing.Point(0, 0);
             this.gbCmd.Name = "gbCmd";
             this.gbCmd.Padding = new System.Windows.Forms.Padding(10, 3, 10, 10);
-            this.gbCmd.Size = new System.Drawing.Size(300, 409);
+            this.gbCmd.Size = new System.Drawing.Size(300, 457);
             this.gbCmd.TabIndex = 0;
             this.gbCmd.TabStop = false;
             this.gbCmd.Text = "Command Parameters";
             // 
             // pnlCmdElem
             // 
+            this.pnlCmdElem.Controls.Add(this.lblCmdScalingExample);
+            this.pnlCmdElem.Controls.Add(this.txtCmdScaling);
+            this.pnlCmdElem.Controls.Add(this.lblCmdScaling);
             this.pnlCmdElem.Controls.Add(this.lblCmdByteOrderExample);
             this.pnlCmdElem.Controls.Add(this.txtCmdByteOrder);
             this.pnlCmdElem.Controls.Add(this.lblCmdByteOrder);
@@ -105,8 +111,35 @@
             this.pnlCmdElem.Controls.Add(this.lblCmdAddress);
             this.pnlCmdElem.Location = new System.Drawing.Point(13, 267);
             this.pnlCmdElem.Name = "pnlCmdElem";
-            this.pnlCmdElem.Size = new System.Drawing.Size(274, 129);
+            this.pnlCmdElem.Size = new System.Drawing.Size(274, 177);
             this.pnlCmdElem.TabIndex = 14;
+            // 
+            // lblCmdScalingExample
+            // 
+            this.lblCmdScalingExample.AutoSize = true;
+            this.lblCmdScalingExample.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblCmdScalingExample.Location = new System.Drawing.Point(137, 154);
+            this.lblCmdScalingExample.Name = "lblCmdScalingExample";
+            this.lblCmdScalingExample.Size = new System.Drawing.Size(126, 15);
+            this.lblCmdScalingExample.TabIndex = 12;
+            this.lblCmdScalingExample.Text = "For example, 0;65535;0;35";
+            // 
+            // txtCmdScaling
+            // 
+            this.txtCmdScaling.Location = new System.Drawing.Point(0, 150);
+            this.txtCmdScaling.Name = "txtCmdScaling";
+            this.txtCmdScaling.Size = new System.Drawing.Size(134, 23);
+            this.txtCmdScaling.TabIndex = 11;
+            this.txtCmdScaling.TextChanged += new System.EventHandler(this.txtCmdScaling_TextChanged);
+            // 
+            // lblCmdScaling
+            // 
+            this.lblCmdScaling.AutoSize = true;
+            this.lblCmdScaling.Location = new System.Drawing.Point(-3, 132);
+            this.lblCmdScaling.Name = "lblCmdScaling";
+            this.lblCmdScaling.Size = new System.Drawing.Size(61, 15);
+            this.lblCmdScaling.TabIndex = 10;
+            this.lblCmdScaling.Text = "Reverse scaling";
             // 
             // lblCmdByteOrderExample
             // 
@@ -401,7 +434,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.gbCmd);
             this.Name = "CtrlCmd";
-            this.Size = new System.Drawing.Size(300, 409);
+            this.Size = new System.Drawing.Size(300, 457);
             this.gbCmd.ResumeLayout(false);
             this.gbCmd.PerformLayout();
             this.pnlCmdElem.ResumeLayout(false);
@@ -436,6 +469,9 @@
         private System.Windows.Forms.Label lblCmdByteOrderExample;
         private System.Windows.Forms.TextBox txtCmdByteOrder;
         private System.Windows.Forms.Label lblCmdByteOrder;
+        private System.Windows.Forms.Label lblCmdScalingExample;
+        private System.Windows.Forms.TextBox txtCmdScaling;
+        private System.Windows.Forms.Label lblCmdScaling;
         private System.Windows.Forms.Label lblCmdAddressHint;
         private System.Windows.Forms.Label lblCmdElemType;
         private System.Windows.Forms.ComboBox cbCmdElemType;

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlCmd.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlCmd.cs
@@ -106,6 +106,7 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
             numCmdAddress.Hexadecimal = !DecAddr;
             ShowFuncCode(cmd);
             ShowByteOrder(cmd);
+            ShowScaling(cmd);
 
             if (cmd == null)
             {
@@ -199,6 +200,23 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
         }
 
         /// <summary>
+        /// Shows the scaling of the command.
+        /// </summary>
+        private void ShowScaling(CmdConfig cmd)
+        {
+            if (cmd != null && cmd.ScalingEnabled)
+            {
+                txtCmdScaling.Text = cmd.Scaling;
+                txtCmdScaling.Enabled = true;
+            }
+            else
+            {
+                txtCmdScaling.Text = "";
+                txtCmdScaling.Enabled = false;
+            }
+        }
+
+        /// <summary>
         /// Raises an ObjectChanged event.
         /// </summary>
         private void OnObjectChanged(object changeArgument)
@@ -271,6 +289,7 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
 
                 ShowFuncCode(cmd);
                 ShowByteOrder(cmd);
+                ShowScaling(cmd);
                 OnObjectChanged(TreeUpdateTypes.CurrentNode);
 
                 if (cmd.DataBlock == DataBlock.Custom)
@@ -299,6 +318,7 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
                 cmd.Multiple = chkCmdMultiple.Checked;
                 ShowFuncCode(cmd);
                 ShowByteOrder(cmd);
+                ShowScaling(cmd);
                 OnObjectChanged(TreeUpdateTypes.None);
 
                 cbCmdElemType.SelectedIndex = (int)cmd.DefaultElemType;
@@ -377,6 +397,16 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
             if (cmd != null)
             {
                 cmd.ByteOrder = txtCmdByteOrder.Text;
+                OnObjectChanged(TreeUpdateTypes.None);
+            }
+        }
+
+        private void txtCmdScaling_TextChanged(object sender, EventArgs e)
+        {
+            // update scaling
+            if (cmd != null)
+            {
+                cmd.Scaling = txtCmdScaling.Text;
                 OnObjectChanged(TreeUpdateTypes.None);
             }
         }

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlElem.Designer.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlElem.Designer.cs
@@ -29,6 +29,9 @@
         private void InitializeComponent()
         {
             this.gbElem = new System.Windows.Forms.GroupBox();
+            this.lblElemScalingExample = new System.Windows.Forms.Label();
+            this.txtElemScaling = new System.Windows.Forms.TextBox();
+            this.lblElemScaling = new System.Windows.Forms.Label();
             this.chkElemIsBitMask = new System.Windows.Forms.CheckBox();
             this.chkElemReadOnly = new System.Windows.Forms.CheckBox();
             this.lblElemByteOrderExample = new System.Windows.Forms.Label();
@@ -62,6 +65,9 @@
             // 
             // gbElem
             // 
+            this.gbElem.Controls.Add(this.lblElemScalingExample);
+            this.gbElem.Controls.Add(this.txtElemScaling);
+            this.gbElem.Controls.Add(this.lblElemScaling);
             this.gbElem.Controls.Add(this.chkElemIsBitMask);
             this.gbElem.Controls.Add(this.chkElemReadOnly);
             this.gbElem.Controls.Add(this.lblElemByteOrderExample);
@@ -89,10 +95,37 @@
             this.gbElem.Location = new System.Drawing.Point(0, 0);
             this.gbElem.Name = "gbElem";
             this.gbElem.Padding = new System.Windows.Forms.Padding(10, 3, 10, 10);
-            this.gbElem.Size = new System.Drawing.Size(300, 395);
+            this.gbElem.Size = new System.Drawing.Size(300, 448);
             this.gbElem.TabIndex = 0;
             this.gbElem.TabStop = false;
             this.gbElem.Text = "Element Parameters";
+            // 
+            // lblElemScalingExample
+            // 
+            this.lblElemScalingExample.AutoSize = true;
+            this.lblElemScalingExample.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblElemScalingExample.Location = new System.Drawing.Point(150, 407);
+            this.lblElemScalingExample.Name = "lblElemScalingExample";
+            this.lblElemScalingExample.Size = new System.Drawing.Size(126, 15);
+            this.lblElemScalingExample.TabIndex = 26;
+            this.lblElemScalingExample.Text = "For example, 0;65535;0;35";
+            // 
+            // txtElemScaling
+            // 
+            this.txtElemScaling.Location = new System.Drawing.Point(13, 403);
+            this.txtElemScaling.Name = "txtElemScaling";
+            this.txtElemScaling.Size = new System.Drawing.Size(134, 23);
+            this.txtElemScaling.TabIndex = 25;
+            this.txtElemScaling.TextChanged += new System.EventHandler(this.txtScaling_TextChanged);
+            // 
+            // lblElemScaling
+            // 
+            this.lblElemScaling.AutoSize = true;
+            this.lblElemScaling.Location = new System.Drawing.Point(10, 385);
+            this.lblElemScaling.Name = "lblElemScaling";
+            this.lblElemScaling.Size = new System.Drawing.Size(61, 15);
+            this.lblElemScaling.TabIndex = 24;
+            this.lblElemScaling.Text = "Scaling";
             // 
             // chkElemIsBitMask
             // 
@@ -362,7 +395,7 @@
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.gbElem);
             this.Name = "CtrlElem";
-            this.Size = new System.Drawing.Size(300, 395);
+            this.Size = new System.Drawing.Size(300, 448);
             this.gbElem.ResumeLayout(false);
             this.gbElem.PerformLayout();
             this.pnlElemTagCodeWarn.ResumeLayout(false);
@@ -378,6 +411,9 @@
         private System.Windows.Forms.Label lblElemByteOrderExample;
         private System.Windows.Forms.TextBox txtElemByteOrder;
         private System.Windows.Forms.Label lblElemByteOrder;
+        private System.Windows.Forms.Label lblElemScalingExample;
+        private System.Windows.Forms.TextBox txtElemScaling;
+        private System.Windows.Forms.Label lblElemScaling;
         private System.Windows.Forms.RadioButton rbDouble;
         private System.Windows.Forms.RadioButton rbLong;
         private System.Windows.Forms.RadioButton rbULong;

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlElem.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Controls/CtrlElem.cs
@@ -61,6 +61,7 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
                 txtElemByteOrder.Text = "";
                 chkElemReadOnly.Checked = false;
                 chkElemIsBitMask.Checked = false;
+                txtElemScaling.Text = "";
                 gbElem.Enabled = false;
             }
             else
@@ -124,6 +125,9 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
                 chkElemReadOnly.Enabled = elemGroup.ReadOnlyEnabled;
                 chkElemIsBitMask.Checked = elem.IsBitMask;
                 chkElemIsBitMask.Enabled = elemGroup.BitMaskEnabled;
+                txtElemScaling.Text = elem.Scaling;
+                txtElemScaling.Enabled = elemGroup.ScalingEnabled &&
+                        (elem.ElemType == ElemType.UShort || elem.ElemType == ElemType.Short);
                 gbElem.Enabled = true;
             }
         }
@@ -205,6 +209,9 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
 
                 elemTag.Elem.ElemType = elemType;
                 txtElemAddress.Text = elemTag.AddressRange;
+                txtElemScaling.Text = elemTag.Elem.Scaling;
+                txtElemScaling.Enabled = elemTag.ElemGroup.ScalingEnabled &&
+                        (elemType == ElemType.UShort || elemType == ElemType.Short);
                 OnObjectChanged(TreeUpdateTypes.CurrentNode | TreeUpdateTypes.NextSiblings);
             }
         }
@@ -235,6 +242,16 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Controls
             if (elemTag != null)
             {
                 elemTag.Elem.IsBitMask = chkElemIsBitMask.Checked;
+                OnObjectChanged(TreeUpdateTypes.None);
+            }
+        }
+
+        private void txtScaling_TextChanged(object sender, EventArgs e)
+        {
+            // update scaling
+            if (elemTag != null)
+            {
+                elemTag.Elem.Scaling = txtElemScaling.Text;
                 OnObjectChanged(TreeUpdateTypes.None);
             }
         }

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Forms/FrmDeviceTemplate.Designer.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Forms/FrmDeviceTemplate.Designer.cs
@@ -330,7 +330,7 @@
             this.ctrlElem.ElemTag = null;
             this.ctrlElem.Location = new System.Drawing.Point(318, 70);
             this.ctrlElem.Name = "ctrlElem";
-            this.ctrlElem.Size = new System.Drawing.Size(300, 395);
+            this.ctrlElem.Size = new System.Drawing.Size(300, 448);
             this.ctrlElem.TabIndex = 3;
             this.ctrlElem.ObjectChanged += new System.EventHandler<Scada.Forms.ObjectChangedEventArgs>(this.ctrlElem_ObjectChanged);
             // 
@@ -340,7 +340,7 @@
             this.ctrlCmd.Cmd = null;
             this.ctrlCmd.Location = new System.Drawing.Point(318, 120);
             this.ctrlCmd.Name = "ctrlCmd";
-            this.ctrlCmd.Size = new System.Drawing.Size(300, 409);
+            this.ctrlCmd.Size = new System.Drawing.Size(300, 457);
             this.ctrlCmd.TabIndex = 4;
             this.ctrlCmd.TemplateOptions = null;
             this.ctrlCmd.ObjectChanged += new System.EventHandler<Scada.Forms.ObjectChangedEventArgs>(this.ctrlCmd_ObjectChanged);

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Forms/FrmDeviceTemplate.cs
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Forms/FrmDeviceTemplate.cs
@@ -842,6 +842,7 @@ namespace Scada.Comm.Drivers.DrvModbus.View.Forms
                         elemConfig.ByteOrder = selectedElem.ByteOrder;
                         elemConfig.ReadOnly = selectedElem.ReadOnly;
                         elemConfig.IsBitMask = selectedElem.IsBitMask;
+                        elemConfig.Scaling = selectedElem.Scaling;
                     }
                 }
 

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Lang/DrvModbus.en-GB.xml
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Lang/DrvModbus.en-GB.xml
@@ -32,6 +32,8 @@
     <Phrase key="lblCmdElemCnt">Element count</Phrase>
     <Phrase key="lblCmdByteOrder">Byte order</Phrase>
     <Phrase key="lblCmdByteOrderExample">For example, 01234567</Phrase>
+    <Phrase key="lblCmdScaling">Reverse scaling</Phrase>
+    <Phrase key="lblCmdScalingExample">For example, 0;65535;0;35</Phrase>
   </Dictionary>
   <Dictionary key="Scada.Comm.Drivers.DrvModbus.View.Controls.CtrlElem">
     <Phrase key="gbElem">Element Parameters</Phrase>
@@ -54,6 +56,8 @@
     <Phrase key="lblElemByteOrderExample">For example, 01234567</Phrase>
     <Phrase key="chkElemReadOnly">Read only</Phrase>
     <Phrase key="chkElemIsBitMask">Bit mask</Phrase>
+    <Phrase key="lblElemScaling">Scaling</Phrase>
+    <Phrase key="lblElemScalingExample">For example, 0;65535;0;35</Phrase>
   </Dictionary>
   <Dictionary key="Scada.Comm.Drivers.DrvModbus.View.Controls.CtrlElemGroup">
     <Phrase key="gbElemGroup">Element Group Parameters</Phrase>

--- a/ScadaComm/OpenDrivers/DrvModbus.View/Lang/DrvModbus.ru-RU.xml
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/Lang/DrvModbus.ru-RU.xml
@@ -32,6 +32,8 @@
     <Phrase key="lblCmdElemCnt">Количество элементов</Phrase>
     <Phrase key="lblCmdByteOrder">Порядок байт</Phrase>
     <Phrase key="lblCmdByteOrderExample">Например, 01234567</Phrase>
+    <Phrase key="lblCmdScaling">Обратное масштабирование</Phrase>
+    <Phrase key="lblCmdScalingExample">Например, 0;65535;0;35</Phrase>
   </Dictionary>
   <Dictionary key="Scada.Comm.Drivers.DrvModbus.View.Controls.CtrlElem">
     <Phrase key="gbElem">Параметры элемента</Phrase>
@@ -54,6 +56,8 @@
     <Phrase key="lblElemByteOrderExample">Например, 01234567</Phrase>
     <Phrase key="chkElemReadOnly">Только чтение</Phrase>
     <Phrase key="chkElemIsBitMask">Битовая маска</Phrase>
+    <Phrase key="lblElemScaling">Масштабирование</Phrase>
+    <Phrase key="lblElemScalingExample">Например, 0;65535;0;35</Phrase>
   </Dictionary>
   <Dictionary key="Scada.Comm.Drivers.DrvModbus.View.Controls.CtrlElemGroup">
     <Phrase key="gbElemGroup">Параметры группы элементов</Phrase>


### PR DESCRIPTION
For example, scale 12-bit or 16-bit analog input raw data to a floating-point value