### PR TITLE
Linux build support: Introduce .slnf filters, update docs, remove obsolete flags

### DIFF
--- a/HowToBuild.txt
+++ b/HowToBuild.txt
@@ -25,15 +25,18 @@ Build with Visual Studio
 
 Build from Command Line
 -----------------------
+
 1. Download and install .NET SDK 8.0 for your operating system.
 
 2. Download the source code of Rapid SCADA from the repository:
    https://github.com/RapidScada/scada-v6
 
 3. Change directory to the source code root.
- 
-4. Execute the following commands:
 
+4. Execute the following commands depending on your platform:
+
+Windows (full build, includes UI and extensions):
+------------------------------------------------
 dotnet build ScadaCommon/ScadaCommon.sln -c Release
 dotnet build ScadaAgent/ScadaAgent/ScadaAgent.sln -c Release
 dotnet build ScadaComm/ScadaComm/ScadaComm.sln -c Release
@@ -47,3 +50,18 @@ dotnet build ScadaServer/OpenModules/OpenModules.sln -c Release
 dotnet build ScadaWeb/Mimics/Mimics.sln -c Release
 dotnet build ScadaWeb/OpenPlugins/OpenPlugins.sln -c Release
 dotnet build ScadaAdmin/OpenExtensions/OpenExtensions.sln -c Release
+
+Linux (cross‑platform build, skips Windows‑only projects):
+----------------------------------------------------------
+dotnet build ScadaCommon/ScadaCommon.slnf -c Release
+dotnet build ScadaAgent/ScadaAgent/ScadaAgent.sln -c Release
+dotnet build ScadaComm/ScadaComm/ScadaComm.sln -c Release
+dotnet build ScadaServer/ScadaServer/ScadaServer.slnf -c Release
+dotnet build ScadaWeb/ScadaWeb/ScadaWeb.sln -c Release
+dotnet build ScadaAdmin/ScadaAdmin/ScadaAdmin.slnf -c Release
+dotnet build ScadaReport/ScadaReport.sln -c Release
+dotnet build ScadaComm/OpenDrivers/OpenDrivers.slnf -c Release
+dotnet build ScadaComm/OpenDrivers2/OpenDrivers2.slnf -c Release
+dotnet build ScadaServer/OpenModules/OpenModules.slnf -c Release
+dotnet build ScadaWeb/Mimics/Mimics.sln -c Release
+dotnet build ScadaWeb/OpenPlugins/OpenPlugins.slnf -c Release

--- a/ScadaAdmin/OpenExtensions/ExtCommConfig/ExtCommConfig.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtCommConfig/ExtCommConfig.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RootNamespace>Scada.Admin.Extensions.ExtCommConfig</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>
     <Company>Rapid Software LLC</Company>

--- a/ScadaAdmin/OpenExtensions/ExtDepAgent/ExtDepAgent.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtDepAgent/ExtDepAgent.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RootNamespace>Scada.Admin.Extensions.ExtDepAgent</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>
     <Company>Rapid Software LLC</Company>

--- a/ScadaAdmin/OpenExtensions/ExtDepPostgreSql/ExtDepPostgreSql.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtDepPostgreSql/ExtDepPostgreSql.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RootNamespace>Scada.Admin.Extensions.ExtDepPostgreSql</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>
     <Company>Rapid Software LLC</Company>

--- a/ScadaAdmin/OpenExtensions/ExtExternalTools/ExtExternalTools.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtExternalTools/ExtExternalTools.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtExternalTools</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/OpenExtensions/ExtMimicLauncher/ExtMimicLauncher.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtMimicLauncher/ExtMimicLauncher.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtMimicLauncher</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/OpenExtensions/ExtProjectTools/ExtProjectTools.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtProjectTools/ExtProjectTools.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtProjectTools</RootNamespace>

--- a/ScadaAdmin/OpenExtensions/ExtServerConfig/ExtServerConfig.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtServerConfig/ExtServerConfig.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtServerConfig</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/OpenExtensions/ExtTableEditor/ExtTableEditor.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtTableEditor/ExtTableEditor.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtTableEditor</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/OpenExtensions/ExtWebConfig/ExtWebConfig.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtWebConfig/ExtWebConfig.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtWebConfig</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/OpenExtensions/ExtWirenBoard/ExtWirenBoard.csproj
+++ b/ScadaAdmin/OpenExtensions/ExtWirenBoard/ExtWirenBoard.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.Extensions.ExtWirenBoard</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/ScadaAdmin/ScadaAdmin.slnf
+++ b/ScadaAdmin/ScadaAdmin/ScadaAdmin.slnf
@@ -1,0 +1,8 @@
+{
+  "solution": {
+    "path": "ScadaAdmin.sln",
+    "projects": [
+      "ScadaAdminCommon.Subset\\ScadaAdminCommon.Subset.csproj"
+    ]
+  }
+}

--- a/ScadaAdmin/ScadaAdmin/ScadaAdmin/ScadaAdmin.csproj
+++ b/ScadaAdmin/ScadaAdmin/ScadaAdmin/ScadaAdmin.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin.App</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaAdmin/ScadaAdmin/ScadaAdminCommon/ScadaAdminCommon.csproj
+++ b/ScadaAdmin/ScadaAdmin/ScadaAdminCommon/ScadaAdminCommon.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Admin</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/ScadaComm/OpenDrivers/DrvCnlBasic.View/DrvCnlBasic.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvCnlBasic.View/DrvCnlBasic.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>Scada.Comm.Drivers.DrvCnlBasic.View</RootNamespace>

--- a/ScadaComm/OpenDrivers/DrvCnlMqtt.View/DrvCnlMqtt.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvCnlMqtt.View/DrvCnlMqtt.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>Scada.Comm.Drivers.DrvCnlMqtt.View</RootNamespace>

--- a/ScadaComm/OpenDrivers/DrvDbImport.View/DrvDbImport.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvDbImport.View/DrvDbImport.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvDbImport.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvDsMqtt.View/DrvDsMqtt.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvDsMqtt.View/DrvDsMqtt.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvDsMqtt.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvDsOpcUaServer.View/DrvDsOpcUaServer.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvDsOpcUaServer.View/DrvDsOpcUaServer.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvDsOpcUaServer.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvDsScadaServer.View/DrvDsScadaServer.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvDsScadaServer.View/DrvDsScadaServer.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvDsScadaServer.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvEnronModbus.View/DrvEnronModbus.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvEnronModbus.View/DrvEnronModbus.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvEnronModbus.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvModbus.View/DrvModbus.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvModbus.View/DrvModbus.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvModbus.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvMqttClient.View/DrvMqttClient.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvMqttClient.View/DrvMqttClient.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvMqttClient.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvMqttPublisher.View/DrvMqttPublisher.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvMqttPublisher.View/DrvMqttPublisher.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvMqttPublisher.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers/DrvOpcUa.View/DrvOpcUa.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvOpcUa.View/DrvOpcUa.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>Scada.Comm.Drivers.DrvOpcUa.View</RootNamespace>

--- a/ScadaComm/OpenDrivers/DrvTester.View/DrvTester.View.csproj
+++ b/ScadaComm/OpenDrivers/DrvTester.View/DrvTester.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvTester.View</RootNamespace>
     <Version>6.0.0</Version>

--- a/ScadaComm/OpenDrivers/OpenDrivers.slnf
+++ b/ScadaComm/OpenDrivers/OpenDrivers.slnf
@@ -1,0 +1,25 @@
+{
+  "solution": {
+    "path": "OpenDrivers.sln",
+    "projects": [
+      "DrvSimulator.Logic\\DrvSimulator.Logic.csproj",
+      "DrvCnlBasic.Logic\\DrvCnlBasic.Logic.csproj",
+      "DrvDsScadaServer.Logic\\DrvDsScadaServer.Logic.csproj",
+      "DrvDsOpcUaServer.Logic\\DrvDsOpcUaServer.Logic.csproj",
+      "DrvDsOpcUaServer.Common\\DrvDsOpcUaServer.Common.csproj",
+      "DrvModbus.Common\\DrvModbus.Common.csproj",
+      "DrvModbus.Logic\\DrvModbus.Logic.csproj",
+      "DrvOpcUa.Logic\\DrvOpcUa.Logic.csproj",
+      "DrvOpcUa.Common\\DrvOpcUa.Common.csproj",
+      "DrvTester.Logic\\DrvTester.Logic.csproj",
+      "DrvMqtt.Common\\DrvMqtt.Common.csproj",
+      "DrvCnlMqtt.Logic\\DrvCnlMqtt.Logic.csproj",
+      "DrvMqttClient.Common\\DrvMqttClient.Common.csproj",
+      "DrvMqttClient.Logic\\DrvMqttClient.Logic.csproj",
+      "DrvMqttPublisher.Logic\\DrvMqttPublisher.Logic.csproj",
+      "DrvDsMqtt.Logic\\DrvDsMqtt.Logic.csproj",
+      "DrvDbImport.Logic\\DrvDbImport.Logic.csproj",
+      "DrvEnronModbus.Logic\\DrvEnronModbus.Logic.csproj"
+    ]
+  }
+}

--- a/ScadaComm/OpenDrivers2/AddressBook.Forms/AddressBook.Forms.csproj
+++ b/ScadaComm/OpenDrivers2/AddressBook.Forms/AddressBook.Forms.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.AB.Forms</RootNamespace>
     <Version>6.0.0</Version>

--- a/ScadaComm/OpenDrivers2/DrvCsvReader.View/DrvCsvReader.View.csproj
+++ b/ScadaComm/OpenDrivers2/DrvCsvReader.View/DrvCsvReader.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvCsvReader.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers2/DrvEmail.View/DrvEmail.View.csproj
+++ b/ScadaComm/OpenDrivers2/DrvEmail.View/DrvEmail.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvEmail.View</RootNamespace>
     <Version>6.0.0</Version>

--- a/ScadaComm/OpenDrivers2/DrvHttpNotif.View/DrvHttpNotif.View.csproj
+++ b/ScadaComm/OpenDrivers2/DrvHttpNotif.View/DrvHttpNotif.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvHttpNotif.View</RootNamespace>
     <Version>6.0.0</Version>

--- a/ScadaComm/OpenDrivers2/DrvSms.View/DrvSms.View.csproj
+++ b/ScadaComm/OpenDrivers2/DrvSms.View/DrvSms.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvSms.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers2/DrvSnmp.View/DrvSnmp.View.csproj
+++ b/ScadaComm/OpenDrivers2/DrvSnmp.View/DrvSnmp.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Comm.Drivers.DrvSnmp.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaComm/OpenDrivers2/OpenDrivers2.slnf
+++ b/ScadaComm/OpenDrivers2/OpenDrivers2.slnf
@@ -1,0 +1,14 @@
+{
+  "solution": {
+    "path": "OpenDrivers2.sln",
+    "projects": [
+      "AddressBook\\AddressBook.csproj",
+      "DrvHttpNotif.Logic\\DrvHttpNotif.Logic.csproj",
+      "DrvEmail.Logic\\DrvEmail.Logic.csproj",
+      "DrvSnmp.Logic\\DrvSnmp.Logic.csproj",
+      "DrvSms.Logic\\DrvSms.Logic.csproj",
+      "DrvSms.Tests\\DrvSms.Tests.csproj",
+      "DrvCsvReader.Logic\\DrvCsvReader.Logic.csproj"
+    ]
+  }
+}

--- a/ScadaCommon/ScadaCommon.Forms/ScadaCommon.Forms.csproj
+++ b/ScadaCommon/ScadaCommon.Forms/ScadaCommon.Forms.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Forms</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/ScadaCommon/ScadaCommon.slnf
+++ b/ScadaCommon/ScadaCommon.slnf
@@ -1,0 +1,12 @@
+{
+  "solution": {
+    "path": "ScadaCommon.sln",
+    "projects": [
+      "ScadaCommon\\ScadaCommon.csproj",
+      "ScadaCommon.Log\\ScadaCommon.Log.csproj",
+      "FileStorage\\FileStorage.csproj",
+      "PostgreSqlStorage\\PostgreSqlStorage.csproj",
+      "ScadaCommon.MultiDb\\ScadaCommon.MultiDb.csproj"
+    ]
+  }
+}

--- a/ScadaServer/OpenModules/ModActiveDirectory.View/ModActiveDirectory.View.csproj
+++ b/ScadaServer/OpenModules/ModActiveDirectory.View/ModActiveDirectory.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Server.Modules.ModActiveDirectory.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaServer/OpenModules/ModArcBasic.View/ModArcBasic.View.csproj
+++ b/ScadaServer/OpenModules/ModArcBasic.View/ModArcBasic.View.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Server.Modules.ModArcBasic.View</RootNamespace>

--- a/ScadaServer/OpenModules/ModArcInfluxDb.View/ModArcInfluxDb.View.csproj
+++ b/ScadaServer/OpenModules/ModArcInfluxDb.View/ModArcInfluxDb.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Server.Modules.ModArcInfluxDb.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaServer/OpenModules/ModArcPostgreSql.View/ModArcPostgreSql.View.csproj
+++ b/ScadaServer/OpenModules/ModArcPostgreSql.View/ModArcPostgreSql.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>Scada.Server.Modules.ModArcPostgreSql.View</RootNamespace>

--- a/ScadaServer/OpenModules/ModDbExport.View/ModDbExport.View.csproj
+++ b/ScadaServer/OpenModules/ModDbExport.View/ModDbExport.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Server.Modules.ModDbExport.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaServer/OpenModules/ModDiffCalculator.View/ModDiffCalculator.View.csproj
+++ b/ScadaServer/OpenModules/ModDiffCalculator.View/ModDiffCalculator.View.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Scada.Server.Modules.ModDiffCalculator.View</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>

--- a/ScadaServer/OpenModules/OpenModules.slnf
+++ b/ScadaServer/OpenModules/OpenModules.slnf
@@ -1,0 +1,13 @@
+{
+  "solution": {
+    "path": "OpenModules.sln",
+    "projects": [
+      "ModArcBasic.Logic\\ModArcBasic.Logic.csproj",
+      "ModArcPostgreSql.Logic\\ModArcPostgreSql.Logic.csproj",
+      "ModArcInfluxDb.Logic\\ModArcInfluxDb.Logic.csproj",
+      "ModActiveDirectory.Logic\\ModActiveDirectory.Logic.csproj",
+      "ModDbExport.Logic\\ModDbExport.Logic.csproj",
+      "ModDiffCalculator.Logic\\ModDiffCalculator.Logic.csproj"
+    ]
+  }
+}

--- a/ScadaServer/ScadaServer/ScadaServer.slnf
+++ b/ScadaServer/ScadaServer/ScadaServer.slnf
@@ -1,0 +1,11 @@
+{
+  "solution": {
+    "path": "ScadaServer.sln",
+    "projects": [
+      "ScadaServerCommon\\ScadaServerCommon.csproj",
+      "ScadaServerEngine\\ScadaServerEngine.csproj",
+      "ScadaServerApp\\ScadaServerApp.csproj",
+      "ScadaServerWkr\\ScadaServerWkr.csproj"
+    ]
+  }
+}

--- a/ScadaServer/ScadaServer/ScadaServerCommon.Forms/ScadaServerCommon.Forms.csproj
+++ b/ScadaServer/ScadaServer/ScadaServerCommon.Forms/ScadaServerCommon.Forms.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RootNamespace>Scada.Server.Forms</RootNamespace>

--- a/ScadaWeb/OpenPlugins/OpenPlugins.slnf
+++ b/ScadaWeb/OpenPlugins/OpenPlugins.slnf
@@ -1,0 +1,17 @@
+{
+  "solution": {
+    "path": "OpenPlugins.sln",
+    "projects": [
+      "PlgMain\\PlgMain.csproj",
+      "PlgMain.Common\\PlgMain.Common.csproj",
+      "PlgChart\\PlgChart.csproj",
+      "PlgChart.Common\\PlgChart.Common.csproj",
+      "PlgScheme\\PlgScheme.csproj",
+      "PlgScheme.Common\\PlgScheme.Common.csproj",
+      "PlgSchBasicComp\\PlgSchBasicComp.csproj",
+      "PlgWebPage\\PlgWebPage.csproj",
+      "PlgMain.Report\\PlgMain.Report.csproj",
+      "PlgScheme.EditorWeb\\PlgScheme.EditorWeb.csproj"
+    ]
+  }
+}

--- a/ScadaWeb/OpenPlugins/PlgScheme.Editor/PlgScheme.Editor.csproj
+++ b/ScadaWeb/OpenPlugins/PlgScheme.Editor/PlgScheme.Editor.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <UseWindowsForms>true</UseWindowsForms>
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <RootNamespace>Scada.Web.Plugins.PlgScheme.Editor</RootNamespace>
     <Authors>Mikhail Shiryaev</Authors>
     <Company>Rapid Software LLC</Company>


### PR DESCRIPTION
This PR improves cross‑platform build support on Linux by:

- Adding solution filter (.slnf) files to exclude Windows‑only projects
- Updating HowToBuild.txt with separate instructions for Windows and Linux
- Removing obsolete <EnableWindowsTargeting> properties, which are ignored since .NET 8

These changes ensure Linux builds succeed without requiring unavailable WindowsDesktop SDKs, 
while Windows builds remain unaffected. The result is a cleaner, more predictable 
cross‑platform build workflow.