### PR TITLE
Fix MQTT protocol version dropdown storing wrong enum value

### DIFF
--- a/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Forms/FrmMqttClientChannelOptions.cs
+++ b/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Forms/FrmMqttClientChannelOptions.cs
@@ -19,6 +19,17 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
         private readonly ChannelConfig channelConfig;   // the communication channel configuration
         private readonly MqttConnectionOptions options; // the connection options
 
+        // Maps cbProtocolVersion combo box index to the corresponding MQTTnet enum value.
+        // The enum is NOT contiguous (Unknown=0, V310=3, V311=4, V500=5), so the index
+        // cannot be cast directly to MqttProtocolVersion.
+        private static readonly MqttProtocolVersion[] ProtocolVersionByIndex =
+        [
+            MqttProtocolVersion.Unknown,
+            MqttProtocolVersion.V310,
+            MqttProtocolVersion.V311,
+            MqttProtocolVersion.V500
+        ];
+
         /// <summary>
         /// Initializes a new instance of the class.
         /// </summary>
@@ -50,7 +61,8 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
             txtClientID.Text = options.ClientID;
             txtUsername.Text = options.Username;
             txtPassword.Text = options.Password;
-            cbProtocolVersion.SelectedIndex = (int)options.ProtocolVersion;
+            int versionIndex = Array.IndexOf(ProtocolVersionByIndex, options.ProtocolVersion);
+            cbProtocolVersion.SelectedIndex = versionIndex >= 0 ? versionIndex : 0;
         }
 
         /// <summary>
@@ -65,7 +77,7 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
             options.ClientID = txtClientID.Text;
             options.Username = txtUsername.Text;
             options.Password = txtPassword.Text;
-            options.ProtocolVersion = (MqttProtocolVersion)cbProtocolVersion.SelectedIndex;
+            options.ProtocolVersion = ProtocolVersionByIndex[cbProtocolVersion.SelectedIndex];
 
             options.AddToOptionList(channelConfig.CustomOptions);
         }


### PR DESCRIPTION
## Summary
`FrmMqttClientChannelOptions` cast the Protocol Version combo box's `SelectedIndex` directly to `MqttProtocolVersion`, but the enum is non-contiguous (`Unknown=0, V310=3, V311=4, V500=5`). Selecting "3.1.1" (index 2) saved the raw value `2` — not a defined enum member — which is then passed straight to MQTTnet's `WithProtocolVersion`.

This silently breaks the connection with an opaque `AggregateException`/`NotSupportedException` ("Specified method is not supported") at connect time, with nothing in the error pointing at the protocol version being the cause.

## Fix
Added an explicit index-to-enum lookup table used by both `OptionsToControls` and `ControlsToOptions`, instead of the direct cast.

## Test plan
- [x] Built `DrvCnlMqtt.View.csproj` (and its `DrvMqtt.Common` dependency) in Release against a clean checkout of `develop`, per `HowToBuild.txt` — builds clean, no warnings.
- [x] Verified selecting each dropdown option (Default/3.1/3.1.1/5.0) now round-trips to the correct `MqttProtocolVersion` value and back to the correct dropdown index.
- [x] Found via a real deployment: an MQTT Publisher line pointed at a cloud broker (EMQX Cloud, TLS, protocol 3.1.1) failed to connect until this was fixed.