### PR TITLE
DrvCnlMqtt: add CA pinning, mutual TLS, and revocation control

### DIFF
--- a/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Forms/FrmMqttClientChannelOptions.Designer.cs
+++ b/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Forms/FrmMqttClientChannelOptions.Designer.cs
@@ -46,6 +46,17 @@
             this.btnCancel = new System.Windows.Forms.Button();
             this.lblUseTls = new System.Windows.Forms.Label();
             this.chkUseTls = new System.Windows.Forms.CheckBox();
+            this.lblCaCertFile = new System.Windows.Forms.Label();
+            this.txtCaCertFile = new System.Windows.Forms.TextBox();
+            this.btnCaCertFileBrowse = new System.Windows.Forms.Button();
+            this.lblClientCertFile = new System.Windows.Forms.Label();
+            this.txtClientCertFile = new System.Windows.Forms.TextBox();
+            this.btnClientCertFileBrowse = new System.Windows.Forms.Button();
+            this.lblClientCertPassword = new System.Windows.Forms.Label();
+            this.txtClientCertPassword = new System.Windows.Forms.TextBox();
+            this.chkAllowUntrustedCertificates = new System.Windows.Forms.CheckBox();
+            this.chkIgnoreCertificateRevocationErrors = new System.Windows.Forms.CheckBox();
+            this.openCertFileDialog = new System.Windows.Forms.OpenFileDialog();
             ((System.ComponentModel.ISupportInitialize)(this.numPort)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numTimeout)).BeginInit();
             this.SuspendLayout();
@@ -98,54 +109,54 @@
             this.lblServer.Text = "Server";
             // 
             // lblClientID
-            // 
+            //
             this.lblClientID.AutoSize = true;
-            this.lblClientID.Location = new System.Drawing.Point(12, 132);
+            this.lblClientID.Location = new System.Drawing.Point(12, 281);
             this.lblClientID.Name = "lblClientID";
             this.lblClientID.Size = new System.Drawing.Size(52, 15);
             this.lblClientID.TabIndex = 8;
             this.lblClientID.Text = "Client ID";
-            // 
+            //
             // txtClientID
-            // 
-            this.txtClientID.Location = new System.Drawing.Point(172, 128);
+            //
+            this.txtClientID.Location = new System.Drawing.Point(172, 277);
             this.txtClientID.Name = "txtClientID";
             this.txtClientID.Size = new System.Drawing.Size(200, 23);
             this.txtClientID.TabIndex = 9;
-            // 
+            //
             // lblUsername
-            // 
+            //
             this.lblUsername.AutoSize = true;
-            this.lblUsername.Location = new System.Drawing.Point(12, 161);
+            this.lblUsername.Location = new System.Drawing.Point(12, 310);
             this.lblUsername.Name = "lblUsername";
             this.lblUsername.Size = new System.Drawing.Size(60, 15);
             this.lblUsername.TabIndex = 10;
             this.lblUsername.Text = "Username";
-            // 
+            //
             // txtUsername
-            // 
-            this.txtUsername.Location = new System.Drawing.Point(172, 157);
+            //
+            this.txtUsername.Location = new System.Drawing.Point(172, 306);
             this.txtUsername.Name = "txtUsername";
             this.txtUsername.Size = new System.Drawing.Size(200, 23);
             this.txtUsername.TabIndex = 11;
-            // 
+            //
             // lblPassword
-            // 
+            //
             this.lblPassword.AutoSize = true;
-            this.lblPassword.Location = new System.Drawing.Point(12, 190);
+            this.lblPassword.Location = new System.Drawing.Point(12, 339);
             this.lblPassword.Name = "lblPassword";
             this.lblPassword.Size = new System.Drawing.Size(57, 15);
             this.lblPassword.TabIndex = 12;
             this.lblPassword.Text = "Password";
-            // 
+            //
             // txtPassword
-            // 
-            this.txtPassword.Location = new System.Drawing.Point(172, 186);
+            //
+            this.txtPassword.Location = new System.Drawing.Point(172, 335);
             this.txtPassword.Name = "txtPassword";
             this.txtPassword.Size = new System.Drawing.Size(200, 23);
             this.txtPassword.TabIndex = 13;
             this.txtPassword.UseSystemPasswordChar = true;
-            // 
+            //
             // lblTimeout
             // 
             this.lblTimeout.AutoSize = true;
@@ -173,16 +184,16 @@
             0});
             // 
             // lblProtocolVersion
-            // 
+            //
             this.lblProtocolVersion.AutoSize = true;
-            this.lblProtocolVersion.Location = new System.Drawing.Point(12, 219);
+            this.lblProtocolVersion.Location = new System.Drawing.Point(12, 368);
             this.lblProtocolVersion.Name = "lblProtocolVersion";
             this.lblProtocolVersion.Size = new System.Drawing.Size(93, 15);
             this.lblProtocolVersion.TabIndex = 14;
             this.lblProtocolVersion.Text = "Protocol version";
-            // 
+            //
             // cbProtocolVersion
-            // 
+            //
             this.cbProtocolVersion.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbProtocolVersion.FormattingEnabled = true;
             this.cbProtocolVersion.Items.AddRange(new object[] {
@@ -190,55 +201,148 @@
             "3.1",
             "3.1.1",
             "5.0"});
-            this.cbProtocolVersion.Location = new System.Drawing.Point(172, 215);
+            this.cbProtocolVersion.Location = new System.Drawing.Point(172, 364);
             this.cbProtocolVersion.Name = "cbProtocolVersion";
             this.cbProtocolVersion.Size = new System.Drawing.Size(200, 23);
             this.cbProtocolVersion.TabIndex = 15;
-            // 
+            //
             // btnOK
-            // 
-            this.btnOK.Location = new System.Drawing.Point(216, 254);
+            //
+            this.btnOK.Location = new System.Drawing.Point(252, 403);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
-            this.btnOK.TabIndex = 16;
+            this.btnOK.TabIndex = 26;
             this.btnOK.Text = "OK";
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
-            // 
+            //
             // btnCancel
-            // 
-            this.btnCancel.Location = new System.Drawing.Point(297, 254);
+            //
+            this.btnCancel.Location = new System.Drawing.Point(333, 403);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
-            this.btnCancel.TabIndex = 17;
+            this.btnCancel.TabIndex = 27;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
-            // 
+            //
             // lblUseTls
-            // 
+            //
             this.lblUseTls.AutoSize = true;
             this.lblUseTls.Location = new System.Drawing.Point(12, 103);
             this.lblUseTls.Name = "lblUseTls";
             this.lblUseTls.Size = new System.Drawing.Size(47, 15);
             this.lblUseTls.TabIndex = 6;
             this.lblUseTls.Text = "Use TLS";
-            // 
+            //
             // chkUseTls
-            // 
+            //
             this.chkUseTls.AutoSize = true;
             this.chkUseTls.Location = new System.Drawing.Point(357, 103);
             this.chkUseTls.Name = "chkUseTls";
             this.chkUseTls.Size = new System.Drawing.Size(15, 14);
             this.chkUseTls.TabIndex = 7;
             this.chkUseTls.UseVisualStyleBackColor = true;
-            // 
+            //
+            // lblCaCertFile
+            //
+            this.lblCaCertFile.AutoSize = true;
+            this.lblCaCertFile.Location = new System.Drawing.Point(12, 136);
+            this.lblCaCertFile.Name = "lblCaCertFile";
+            this.lblCaCertFile.Size = new System.Drawing.Size(103, 15);
+            this.lblCaCertFile.TabIndex = 18;
+            this.lblCaCertFile.Text = "CA certificate file";
+            //
+            // txtCaCertFile
+            //
+            this.txtCaCertFile.Location = new System.Drawing.Point(172, 132);
+            this.txtCaCertFile.Name = "txtCaCertFile";
+            this.txtCaCertFile.Size = new System.Drawing.Size(190, 23);
+            this.txtCaCertFile.TabIndex = 19;
+            //
+            // btnCaCertFileBrowse
+            //
+            this.btnCaCertFileBrowse.Location = new System.Drawing.Point(368, 131);
+            this.btnCaCertFileBrowse.Name = "btnCaCertFileBrowse";
+            this.btnCaCertFileBrowse.Size = new System.Drawing.Size(28, 25);
+            this.btnCaCertFileBrowse.TabIndex = 20;
+            this.btnCaCertFileBrowse.Text = "...";
+            this.btnCaCertFileBrowse.UseVisualStyleBackColor = true;
+            this.btnCaCertFileBrowse.Click += new System.EventHandler(this.btnCaCertFileBrowse_Click);
+            //
+            // lblClientCertFile
+            //
+            this.lblClientCertFile.AutoSize = true;
+            this.lblClientCertFile.Location = new System.Drawing.Point(12, 165);
+            this.lblClientCertFile.Name = "lblClientCertFile";
+            this.lblClientCertFile.Size = new System.Drawing.Size(94, 15);
+            this.lblClientCertFile.TabIndex = 21;
+            this.lblClientCertFile.Text = "Client cert file";
+            //
+            // txtClientCertFile
+            //
+            this.txtClientCertFile.Location = new System.Drawing.Point(172, 161);
+            this.txtClientCertFile.Name = "txtClientCertFile";
+            this.txtClientCertFile.Size = new System.Drawing.Size(190, 23);
+            this.txtClientCertFile.TabIndex = 22;
+            //
+            // btnClientCertFileBrowse
+            //
+            this.btnClientCertFileBrowse.Location = new System.Drawing.Point(368, 160);
+            this.btnClientCertFileBrowse.Name = "btnClientCertFileBrowse";
+            this.btnClientCertFileBrowse.Size = new System.Drawing.Size(28, 25);
+            this.btnClientCertFileBrowse.TabIndex = 23;
+            this.btnClientCertFileBrowse.Text = "...";
+            this.btnClientCertFileBrowse.UseVisualStyleBackColor = true;
+            this.btnClientCertFileBrowse.Click += new System.EventHandler(this.btnClientCertFileBrowse_Click);
+            //
+            // lblClientCertPassword
+            //
+            this.lblClientCertPassword.AutoSize = true;
+            this.lblClientCertPassword.Location = new System.Drawing.Point(12, 194);
+            this.lblClientCertPassword.Name = "lblClientCertPassword";
+            this.lblClientCertPassword.Size = new System.Drawing.Size(122, 15);
+            this.lblClientCertPassword.TabIndex = 24;
+            this.lblClientCertPassword.Text = "Client cert password";
+            //
+            // txtClientCertPassword
+            //
+            this.txtClientCertPassword.Location = new System.Drawing.Point(172, 190);
+            this.txtClientCertPassword.Name = "txtClientCertPassword";
+            this.txtClientCertPassword.Size = new System.Drawing.Size(200, 23);
+            this.txtClientCertPassword.TabIndex = 25;
+            this.txtClientCertPassword.UseSystemPasswordChar = true;
+            //
+            // chkAllowUntrustedCertificates
+            //
+            this.chkAllowUntrustedCertificates.AutoSize = true;
+            this.chkAllowUntrustedCertificates.Location = new System.Drawing.Point(172, 219);
+            this.chkAllowUntrustedCertificates.Name = "chkAllowUntrustedCertificates";
+            this.chkAllowUntrustedCertificates.Size = new System.Drawing.Size(216, 19);
+            this.chkAllowUntrustedCertificates.TabIndex = 17;
+            this.chkAllowUntrustedCertificates.Text = "Allow untrusted certificates";
+            this.chkAllowUntrustedCertificates.UseVisualStyleBackColor = true;
+            //
+            // chkIgnoreCertificateRevocationErrors
+            //
+            this.chkIgnoreCertificateRevocationErrors.AutoSize = true;
+            this.chkIgnoreCertificateRevocationErrors.Location = new System.Drawing.Point(172, 248);
+            this.chkIgnoreCertificateRevocationErrors.Name = "chkIgnoreCertificateRevocationErrors";
+            this.chkIgnoreCertificateRevocationErrors.Size = new System.Drawing.Size(240, 19);
+            this.chkIgnoreCertificateRevocationErrors.TabIndex = 18;
+            this.chkIgnoreCertificateRevocationErrors.Text = "Ignore certificate revocation errors";
+            this.chkIgnoreCertificateRevocationErrors.UseVisualStyleBackColor = true;
+            //
+            // openCertFileDialog
+            //
+            this.openCertFileDialog.Filter = "Certificate files|*.pem;*.crt;*.cer;*.pfx;*.p12|All files|*.*";
+            //
             // FrmMqttClientChannelOptions
-            // 
+            //
             this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(384, 289);
+            this.ClientSize = new System.Drawing.Size(420, 438);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnOK);
             this.Controls.Add(this.cbProtocolVersion);
@@ -249,6 +353,16 @@
             this.Controls.Add(this.lblUsername);
             this.Controls.Add(this.txtClientID);
             this.Controls.Add(this.lblClientID);
+            this.Controls.Add(this.chkIgnoreCertificateRevocationErrors);
+            this.Controls.Add(this.chkAllowUntrustedCertificates);
+            this.Controls.Add(this.txtClientCertPassword);
+            this.Controls.Add(this.lblClientCertPassword);
+            this.Controls.Add(this.btnClientCertFileBrowse);
+            this.Controls.Add(this.txtClientCertFile);
+            this.Controls.Add(this.lblClientCertFile);
+            this.Controls.Add(this.btnCaCertFileBrowse);
+            this.Controls.Add(this.txtCaCertFile);
+            this.Controls.Add(this.lblCaCertFile);
             this.Controls.Add(this.chkUseTls);
             this.Controls.Add(this.lblUseTls);
             this.Controls.Add(this.numTimeout);
@@ -292,5 +406,16 @@
         private Button btnCancel;
         private Label lblUseTls;
         private CheckBox chkUseTls;
+        private Label lblCaCertFile;
+        private TextBox txtCaCertFile;
+        private Button btnCaCertFileBrowse;
+        private Label lblClientCertFile;
+        private TextBox txtClientCertFile;
+        private Button btnClientCertFileBrowse;
+        private Label lblClientCertPassword;
+        private TextBox txtClientCertPassword;
+        private CheckBox chkAllowUntrustedCertificates;
+        private CheckBox chkIgnoreCertificateRevocationErrors;
+        private OpenFileDialog openCertFileDialog;
     }
 }

--- a/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Forms/FrmMqttClientChannelOptions.cs
+++ b/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Forms/FrmMqttClientChannelOptions.cs
@@ -62,6 +62,11 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
             txtPassword.Text = options.Password;
             int versionIndex = Array.IndexOf(ProtocolVersionByIndex, options.ProtocolVersion);
             cbProtocolVersion.SelectedIndex = versionIndex >= 0 ? versionIndex : 0;
+            txtCaCertFile.Text = options.CaCertFile;
+            txtClientCertFile.Text = options.ClientCertFile;
+            txtClientCertPassword.Text = options.ClientCertPassword;
+            chkAllowUntrustedCertificates.Checked = options.AllowUntrustedCertificates;
+            chkIgnoreCertificateRevocationErrors.Checked = options.IgnoreCertificateRevocationErrors;
         }
 
         /// <summary>
@@ -77,6 +82,11 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
             options.Username = txtUsername.Text;
             options.Password = txtPassword.Text;
             options.ProtocolVersion = ProtocolVersionByIndex[cbProtocolVersion.SelectedIndex];
+            options.CaCertFile = txtCaCertFile.Text;
+            options.ClientCertFile = txtClientCertFile.Text;
+            options.ClientCertPassword = txtClientCertPassword.Text;
+            options.AllowUntrustedCertificates = chkAllowUntrustedCertificates.Checked;
+            options.IgnoreCertificateRevocationErrors = chkIgnoreCertificateRevocationErrors.Checked;
 
             options.AddToOptionList(channelConfig.CustomOptions);
         }
@@ -90,6 +100,12 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
 
             if (string.IsNullOrWhiteSpace(txtServer.Text))
                 sbError.AppendError(lblServer, CommonPhrases.NonemptyRequired);
+
+            if (!string.IsNullOrEmpty(txtCaCertFile.Text) && !File.Exists(txtCaCertFile.Text))
+                sbError.AppendError(lblCaCertFile, CommonPhrases.FileNotFound);
+
+            if (!string.IsNullOrEmpty(txtClientCertFile.Text) && !File.Exists(txtClientCertFile.Text))
+                sbError.AppendError(lblClientCertFile, CommonPhrases.FileNotFound);
 
             if (sbError.Length > 0)
             {
@@ -116,6 +132,22 @@ namespace Scada.Comm.Drivers.DrvCnlMqtt.View.Forms
                 ControlsToOptions();
                 DialogResult = DialogResult.OK;
             }
+        }
+
+        private void btnCaCertFileBrowse_Click(object sender, EventArgs e)
+        {
+            openCertFileDialog.FileName = txtCaCertFile.Text;
+
+            if (openCertFileDialog.ShowDialog() == DialogResult.OK)
+                txtCaCertFile.Text = openCertFileDialog.FileName;
+        }
+
+        private void btnClientCertFileBrowse_Click(object sender, EventArgs e)
+        {
+            openCertFileDialog.FileName = txtClientCertFile.Text;
+
+            if (openCertFileDialog.ShowDialog() == DialogResult.OK)
+                txtClientCertFile.Text = openCertFileDialog.FileName;
         }
     }
 }

--- a/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Lang/DrvCnlMqtt.en-GB.xml
+++ b/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Lang/DrvCnlMqtt.en-GB.xml
@@ -6,6 +6,11 @@
     <Phrase key="lblPort">TCP port</Phrase>
     <Phrase key="lblTimeout">Timeout, ms</Phrase>
     <Phrase key="lblUseTls">Use TLS</Phrase>
+    <Phrase key="lblCaCertFile">CA certificate file</Phrase>
+    <Phrase key="lblClientCertFile">Client cert file</Phrase>
+    <Phrase key="lblClientCertPassword">Client cert password</Phrase>
+    <Phrase key="chkAllowUntrustedCertificates">Allow untrusted certificates</Phrase>
+    <Phrase key="chkIgnoreCertificateRevocationErrors">Ignore certificate revocation errors</Phrase>
     <Phrase key="lblClientID">Client ID</Phrase>
     <Phrase key="lblUsername">Username</Phrase>
     <Phrase key="lblPassword">Password</Phrase>

--- a/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Lang/DrvCnlMqtt.ru-RU.xml
+++ b/ScadaComm/OpenDrivers/DrvCnlMqtt.View/Lang/DrvCnlMqtt.ru-RU.xml
@@ -6,6 +6,11 @@
     <Phrase key="lblPort">TCP-порт</Phrase>
     <Phrase key="lblTimeout">Таймаут, мс</Phrase>
     <Phrase key="lblUseTls">Использовать TLS</Phrase>
+    <Phrase key="lblCaCertFile">Файл сертификата CA</Phrase>
+    <Phrase key="lblClientCertFile">Файл сертификата клиента</Phrase>
+    <Phrase key="lblClientCertPassword">Пароль сертификата клиента</Phrase>
+    <Phrase key="chkAllowUntrustedCertificates">Разрешить недоверенные сертификаты</Phrase>
+    <Phrase key="chkIgnoreCertificateRevocationErrors">Игнорировать ошибки отзыва сертификата</Phrase>
     <Phrase key="lblClientID">Идентификатор клиента</Phrase>
     <Phrase key="lblUsername">Имя пользователя</Phrase>
     <Phrase key="lblPassword">Пароль</Phrase>

--- a/ScadaComm/OpenDrivers/DrvMqtt.Common/MqttClientHelper.cs
+++ b/ScadaComm/OpenDrivers/DrvMqtt.Common/MqttClientHelper.cs
@@ -101,9 +101,10 @@ namespace Scada.Comm.Drivers.DrvMqtt
             }
             catch (Exception ex)
             {
+                Exception realEx = ex is AggregateException aggEx ? aggEx.Flatten().InnerException : ex;
                 log.WriteError(Locale.IsRussian ?
                     "Ошибка при установке соединения: {0}" :
-                    "Error connecting: {0}", ex.Message);
+                    "Error connecting: {0}", realEx?.ToString() ?? ex.ToString());
                 return false;
             }
         }

--- a/ScadaComm/OpenDrivers/DrvMqtt.Common/MqttConnectionOptions.cs
+++ b/ScadaComm/OpenDrivers/DrvMqtt.Common/MqttConnectionOptions.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Rapid Software LLC. All rights reserved.
+// Copyright (c) Rapid Software LLC. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using MQTTnet.Client;
 using MQTTnet.Formatter;
 using Scada.Config;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Scada.Comm.Drivers.DrvMqtt
 {
@@ -26,6 +27,11 @@ namespace Scada.Comm.Drivers.DrvMqtt
             Username = "";
             Password = "";
             ProtocolVersion = MqttProtocolVersion.Unknown;
+            CaCertFile = "";
+            ClientCertFile = "";
+            ClientCertPassword = "";
+            AllowUntrustedCertificates = false;
+            IgnoreCertificateRevocationErrors = false;
         }
 
         /// <summary>
@@ -41,6 +47,11 @@ namespace Scada.Comm.Drivers.DrvMqtt
             Username = options.GetValueAsString("Username");
             Password = ScadaUtils.Decrypt(options.GetValueAsString("Password"));
             ProtocolVersion = options.GetValueAsEnum("ProtocolVersion", MqttProtocolVersion.Unknown);
+            CaCertFile = options.GetValueAsString("CaCertFile");
+            ClientCertFile = options.GetValueAsString("ClientCertFile");
+            ClientCertPassword = ScadaUtils.Decrypt(options.GetValueAsString("ClientCertPassword"));
+            AllowUntrustedCertificates = options.GetValueAsBool("AllowUntrustedCertificates");
+            IgnoreCertificateRevocationErrors = options.GetValueAsBool("IgnoreCertificateRevocationErrors");
         }
 
 
@@ -84,6 +95,35 @@ namespace Scada.Comm.Drivers.DrvMqtt
         /// </summary>
         public MqttProtocolVersion ProtocolVersion { get; set; }
 
+        /// <summary>
+        /// Gets or sets the path to a CA certificate file used to validate the broker,
+        /// instead of the operating system trust store. Use for a private or self-signed CA.
+        /// </summary>
+        public string CaCertFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to a client certificate file (PFX/P12) presented to the
+        /// broker for mutual TLS authentication.
+        /// </summary>
+        public string ClientCertFile { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password protecting the client certificate file.
+        /// </summary>
+        public string ClientCertPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to accept the broker certificate
+        /// without validating it. Ignored if CaCertFile is specified.
+        /// </summary>
+        public bool AllowUntrustedCertificates { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to ignore certificate revocation
+        /// check failures, useful for private CAs that don't publish CRL/OCSP endpoints.
+        /// </summary>
+        public bool IgnoreCertificateRevocationErrors { get; set; }
+
 
         /// <summary>
         /// Adds the options to the list.
@@ -101,6 +141,42 @@ namespace Scada.Comm.Drivers.DrvMqtt
             options["Timeout"] = Timeout.ToString();
             options["UseTls"] = UseTls.ToLowerString();
             options["ProtocolVersion"] = ProtocolVersion.ToString();
+            options["CaCertFile"] = CaCertFile;
+            options["ClientCertFile"] = ClientCertFile;
+            options["ClientCertPassword"] = ScadaUtils.Encrypt(ClientCertPassword);
+            options["AllowUntrustedCertificates"] = AllowUntrustedCertificates.ToLowerString();
+            options["IgnoreCertificateRevocationErrors"] = IgnoreCertificateRevocationErrors.ToLowerString();
+        }
+
+        /// <summary>
+        /// Builds a certificate validation handler that trusts only the specified CA certificate,
+        /// instead of the operating system trust store. Supports private and self-signed CAs.
+        /// </summary>
+        private Func<MqttClientCertificateValidationEventArgs, bool> CreateCaValidationHandler()
+        {
+            X509Certificate2 caCert = new(CaCertFile);
+
+            return context =>
+            {
+                using X509Certificate2 serverCert = new(context.Certificate);
+                using X509Chain chain = new();
+                chain.ChainPolicy.RevocationMode = IgnoreCertificateRevocationErrors
+                    ? X509RevocationMode.NoCheck
+                    : X509RevocationMode.Online;
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.Add(caCert);
+                return chain.Build(serverCert);
+            };
+        }
+
+        /// <summary>
+        /// Loads the client certificate used for mutual TLS authentication.
+        /// </summary>
+        private X509Certificate2 LoadClientCert()
+        {
+            return string.IsNullOrEmpty(ClientCertPassword)
+                ? new X509Certificate2(ClientCertFile)
+                : new X509Certificate2(ClientCertFile, ClientCertPassword);
         }
 
         /// <summary>
@@ -115,7 +191,33 @@ namespace Scada.Comm.Drivers.DrvMqtt
                 builder.WithTimeout(TimeSpan.FromMilliseconds(Timeout));
 
             if (UseTls)
-                builder.WithTlsOptions(o => o.UseTls());
+            {
+                builder.WithTlsOptions(o =>
+                {
+                    o.UseTls();
+
+                    if (!string.IsNullOrEmpty(CaCertFile))
+                    {
+                        // Pin a private/self-signed CA instead of trusting the OS store.
+                        o.WithCertificateValidationHandler(CreateCaValidationHandler());
+                    }
+                    else if (AllowUntrustedCertificates)
+                    {
+                        o.WithAllowUntrustedCertificates();
+                        o.WithIgnoreCertificateChainErrors();
+
+                        if (IgnoreCertificateRevocationErrors)
+                            o.WithIgnoreCertificateRevocationErrors();
+                    }
+                    else if (IgnoreCertificateRevocationErrors)
+                    {
+                        o.WithIgnoreCertificateRevocationErrors();
+                    }
+
+                    if (!string.IsNullOrEmpty(ClientCertFile))
+                        o.WithClientCertificates(new X509Certificate2Collection(LoadClientCert()));
+                });
+            }
 
             if (!string.IsNullOrEmpty(ClientID))
                 builder.WithClientId(ClientID);


### PR DESCRIPTION
## Summary
The MQTT channel driver's `UseTls` option only ever called `MqttClientTlsOptionsBuilder.UseTls()` with no further configuration. That's fine against a broker with a publicly-trusted certificate, but there was no way to:
- trust a private or self-signed CA
- present a client certificate for mutual TLS
- control revocation-check behavior

MQTTnet itself already supports all of this (`WithCertificateValidationHandler`, `WithClientCertificates`, `WithIgnoreCertificateRevocationErrors`, etc.) — it just wasn't exposed through `MqttConnectionOptions` or the options dialog.

## What's added
Four new connection options on `MqttConnectionOptions`, all optional and off by default (fully backward compatible — verified the sibling `DrvMqttClient`/`DrvMqttPublisher` drivers that also reference `DrvMqtt.Common` still build unchanged):

- **`CaCertFile`** — pins the broker's certificate chain to a specific CA file via a custom `X509Chain` (`X509ChainTrustMode.CustomRootTrust`), instead of trusting whatever happens to be in the OS trust store. This performs real chain validation against the given CA — it is not a bypass.
- **`ClientCertFile` / `ClientCertPassword`** — presents a client certificate (PFX) for mutual TLS authentication.
- **`AllowUntrustedCertificates`** — explicit opt-in bypass, only applied when no `CaCertFile` is given.
- **`IgnoreCertificateRevocationErrors`** — skips CRL/OCSP revocation checking. Useful because ScadaComm often runs as a Windows service account (e.g. `LocalSystem`), which can fail to complete an online revocation check — and that failure surfaces as an opaque `NotSupportedException` ("Specified method is not supported") with nothing indicating revocation checking was the cause.

Also improved `MqttClientHelper`'s connection error logging: it previously logged only the wrapping `AggregateException`'s generic message ("One or more errors occurred."), discarding the real inner exception and stack trace. It now unwraps and logs the actual cause — which is what made the revocation-check failure above diagnosable in the first place, instead of a dead-end guess.

The options dialog (`FrmMqttClientChannelOptions`) gains matching fields: CA certificate file / client certificate file (with browse buttons), client certificate password, and the two checkboxes. English and Russian language files updated.

## Test plan
- [x] Built `DrvCnlMqtt.View.csproj` and `DrvMqtt.Common.csproj` in Release against a clean checkout of `develop`, per `HowToBuild.txt`.
- [x] Verified `DrvCnlMqtt.Logic`, `DrvMqttClient.Logic`, and `DrvMqttPublisher.Logic` (all consumers of `DrvMqtt.Common`) still build unchanged against the extended options class.
- [x] Deployed to a real ScadaComm6 instance connecting to EMQX Cloud over TLS with a pinned CA cert (`CaCertFile`) — confirmed `MqttClientHelper.Connect()` succeeds and the line shows "MQTT client, connected".
- [x] Verified the CA-pinning path rejects a connection when the presented cert doesn't chain to the configured CA (not just a blanket accept).

Note: this PR is independent of #125 (protocol version dropdown fix) — they don't depend on each other and can be reviewed/merged separately.